### PR TITLE
クエリパラメータをルーティングに移行

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { HomeScreen } from "@/screens/Home";
 
-export default function Home({ searchParams }: { searchParams: { tag: string; writer: string } }) {
-  return <HomeScreen tag={searchParams.tag} writer={searchParams.writer} />;
+export default function Home() {
+  return <HomeScreen />;
 }

--- a/src/app/tag/[tag]/page.tsx
+++ b/src/app/tag/[tag]/page.tsx
@@ -1,4 +1,29 @@
 import { HomeScreen } from "@/screens/Home";
+import { getDatabase } from "@/utils/notion";
+
+export async function generateStaticParams() {
+  const databaseId = process.env.NOTION_DATABASE_ID;
+  const articleDb = await getDatabase(databaseId);
+
+  const results = articleDb
+    .filter((article: any) => {
+      return article.properties.Publish.checkbox === true;
+    })
+    .map((article: any) => {
+      return article.properties.tag.multi_select.name;
+    })
+    .flat();
+
+  const uniqueResults = [...new Set(results)];
+
+  return uniqueResults.map((tag) => {
+    return {
+      params: {
+        tag: encodeURIComponent(tag),
+      },
+    };
+  });
+}
 
 export default function Page({ params }: { params: { tag: string } }) {
   params.tag = decodeURIComponent(params.tag); // 日本語のタグをデコード

--- a/src/app/tag/[tag]/page.tsx
+++ b/src/app/tag/[tag]/page.tsx
@@ -1,0 +1,6 @@
+import { HomeScreen } from "@/screens/Home";
+
+export default function Page({ params }: { params: { tag: string } }) {
+  params.tag = decodeURIComponent(params.tag); // 日本語のタグをデコード
+  return <HomeScreen tag={params.tag} />;
+}

--- a/src/app/writer/[writer]/page.tsx
+++ b/src/app/writer/[writer]/page.tsx
@@ -1,0 +1,6 @@
+import { HomeScreen } from "@/screens/Home";
+
+export default function Page({ params }: { params: { writer: string } }) {
+  params.writer = decodeURIComponent(params.writer); // 日本語のWriterをデコード
+  return <HomeScreen writer={params.writer} />;
+}

--- a/src/app/writer/[writer]/page.tsx
+++ b/src/app/writer/[writer]/page.tsx
@@ -1,4 +1,28 @@
 import { HomeScreen } from "@/screens/Home";
+import { getDatabase } from "@/utils/notion";
+
+export async function generateStaticParams() {
+  const databaseId = process.env.NOTION_DATABASE_ID;
+  const articleDb = await getDatabase(databaseId);
+
+  const results = articleDb
+    .filter((article: any) => {
+      return article.properties.Publish.checkbox === true;
+    })
+    .map((article: any) => {
+      return article.properties.Writer.created_by.name;
+    });
+
+  const uniqueResults = [...new Set(results)];
+
+  return uniqueResults.map((writer) => {
+    return {
+      params: {
+        writer: encodeURIComponent(writer),
+      },
+    };
+  });
+}
 
 export default function Page({ params }: { params: { writer: string } }) {
   params.writer = decodeURIComponent(params.writer); // 日本語のWriterをデコード

--- a/src/features/ArticleList/hooks/index.ts
+++ b/src/features/ArticleList/hooks/index.ts
@@ -2,7 +2,7 @@ import { getDatabase } from "@/utils/notion";
 import { Props as ArticleListItemProps } from "../presentations/ArticleListItem";
 import createImage from "@/utils/createImage";
 
-export const useArticles = async (tagParam: string, writerParam: string) => {
+export const useArticles = async (tagParam?: string, writerParam?: string) => {
   const databaseId = process.env.NOTION_DATABASE_ID;
   const articleDb = await getDatabase(databaseId);
 

--- a/src/features/ArticleList/index.tsx
+++ b/src/features/ArticleList/index.tsx
@@ -3,8 +3,8 @@ import { ArticleListPresentation } from "./presentations/";
 import { useArticles } from "./hooks";
 
 type Props = {
-  tag: string;
-  writer: string;
+  tag?: string;
+  writer?: string;
 };
 
 export const ArticleList: React.FC<Props> = async ({ tag, writer }) => {

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -3,8 +3,8 @@ import { SearchTags } from "@/features/SearchTags";
 import { SearchWriters } from "@/features/SearchWriters";
 
 type Props = {
-  tag: string;
-  writer: string;
+  tag?: string;
+  writer?: string;
 };
 
 export const HomeScreen: React.FC<Props> = async ({ tag, writer }) => {

--- a/src/ui/Tag/index.tsx
+++ b/src/ui/Tag/index.tsx
@@ -13,7 +13,7 @@ export const Tag: React.FC<Props> = ({ name, color, isLink = false }) => {
 
   return isLink ? (
     <Link
-      href={`/?tag=${name}`}
+      href={`/tag/${name}`}
       className="rounded px-20 py-10 text-detail2 text-white hover:opacity-80 active:opacity-60"
       style={{
         backgroundColor: colorCode,

--- a/src/ui/Writer/index.tsx
+++ b/src/ui/Writer/index.tsx
@@ -8,7 +8,7 @@ export type Props = {
 
 export const Writer: React.FC<Props> = ({ name, image }) => {
   return (
-    <Link className="flex items-center gap-30 hover:underline" href={`/?writer=${name}`}>
+    <Link className="flex items-center gap-30 hover:underline" href={`/writer/${name}`}>
       <img
         src={image}
         alt={name}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
SSGではクエリパラメータの仕組みを使用できなかったため、タグ検索、作者検索をurlのルーティングで検索する様に変更しました。