### PR TITLE
スタイルの微調整

### DIFF
--- a/src/features/ArticleDetailBody/hooks/renderBlock.tsx
+++ b/src/features/ArticleDetailBody/hooks/renderBlock.tsx
@@ -94,7 +94,7 @@ export const renderBlock = async (block: any, pageId: string) => {
 
       const caption = value.caption ? value.caption[0]?.plain_text : "";
       return (
-        <figure>
+        <figure className="mx-auto">
           <img src={src} alt={caption} />
           {caption && <figcaption>{caption}</figcaption>}
         </figure>

--- a/src/features/ArticleDetailBody/presentations/blocks/code/index.tsx
+++ b/src/features/ArticleDetailBody/presentations/blocks/code/index.tsx
@@ -8,7 +8,11 @@ type Props = {
 
 export const CodePresentation: React.FC<Props> = ({ code, language }) => {
   return (
-    <SyntaxHighlighter language={language} style={nord} className="[&>code]:block [&>code]:w-[0px]">
+    <SyntaxHighlighter
+      language={language}
+      style={nord}
+      className="text-[14px] [&>code]:block [&>code]:w-[0px]"
+    >
       {code}
     </SyntaxHighlighter>
   );

--- a/src/features/ArticleDetailBody/presentations/index.tsx
+++ b/src/features/ArticleDetailBody/presentations/index.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export const ArticleDetailBodyPresentation: React.FC<Props> = ({ children }) => {
   return (
-    <section className="flex w-full max-w-[720px] flex-col gap-60 bg-white px-40 py-70 md:rounded-2xl md:px-70 md:py-90 md:drop-shadow-sm [&>*]:min-w-0">
+    <section className="flex w-full max-w-[1000px] flex-col gap-60 bg-white px-50 py-70 sm:px-80 md:rounded-2xl md:px-150 md:py-90 md:drop-shadow-sm [&>*]:min-w-0">
       {children}
     </section>
   );


### PR DESCRIPTION
- 記事の左右の余白を追加
- コードブロックのフォントサイズを小さくした
- 写真を中央に寄せた